### PR TITLE
Fix RPCProtocol negative unacknowledged count issue

### DIFF
--- a/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/ipc/proxy/RPCProtocol.kt
+++ b/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/ipc/proxy/RPCProtocol.kt
@@ -226,6 +226,12 @@ class RPCProtocol(
      * Triggered when an acknowledge response is received
      */
     private fun onDidReceiveAcknowledge(req: Int) {
+       // Prevent negative unacknowledged count
+       if (unacknowledgedCount <= 0) {
+           LOG.warn("Received acknowledge but unacknowledgedCount is already $unacknowledgedCount, ignoring. Request ID: $req")
+           return
+       }
+       
        // The next possible unresponsive time is now + increment
        unresponsiveTime = System.currentTimeMillis() + UNRESPONSIVE_TIME
        unacknowledgedCount--
@@ -246,8 +252,13 @@ class RPCProtocol(
      * Check for unresponsiveness
      */
     private fun checkUnresponsive() {
-        if (unacknowledgedCount == 0) {
+        if (unacknowledgedCount <= 0) {
             // Not waiting for anything => cannot determine responsiveness
+            // Also handle negative count case to prevent incorrect state
+            if (unacknowledgedCount < 0) {
+                LOG.warn("Unacknowledged count is negative: $unacknowledgedCount, resetting to 0")
+                unacknowledgedCount = 0
+            }
             return
         }
         


### PR DESCRIPTION
## Summary
This PR fixes issue #59 where RPCProtocol enters an unresponsive state with a negative value for unacknowledged requests.

## Problem
The bug log shows that `unacknowledgedCount` can become negative (-5), which causes continuous warnings about unresponsive state. This happens when acknowledgments are received without corresponding requests or when duplicate acknowledgments are received.

## Solution
1. Added a check in `onDidReceiveAcknowledge()` to prevent decrementing the count when it's already 0 or negative
2. Added a safeguard in `checkUnresponsive()` to reset negative count to 0
3. Added warning logs to help debug when unexpected acknowledgments are received

## Changes
- Modified `RPCProtocol.kt` to add defensive checks against negative unacknowledged count
- Added appropriate warning logs for debugging

## Testing
The fix prevents the negative count scenario and properly handles edge cases where acknowledgments are received unexpectedly.

Fixes wecode-ai/RunVSAgent#59

🤖 Generated with [Claude Code](https://claude.ai/code)