### PR TITLE
Fix Wayland clipboard paste issue in WebView input fields (Issue #76)

### DIFF
--- a/jetbrains_plugin/build.gradle.kts
+++ b/jetbrains_plugin/build.gradle.kts
@@ -230,6 +230,8 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.10.0")
     implementation("com.google.code.gson:gson:2.10.1")
     testImplementation("junit:junit:4.13.2")
+    testImplementation("io.mockk:mockk:1.13.8")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.4")
 }
 

--- a/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/actors/MainThreadClipboardShape.kt
+++ b/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/actors/MainThreadClipboardShape.kt
@@ -6,9 +6,12 @@ package com.sina.weibo.agent.actors
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.util.ui.EmptyClipboardOwner
 import java.awt.Toolkit
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
 
 /**
  * Main thread clipboard interface.
@@ -31,17 +34,41 @@ interface MainThreadClipboardShape : Disposable {
 /**
  * Implementation of the MainThreadClipboardShape interface.
  * Provides functionality to read from and write to the system clipboard.
+ * Supports both X11 and Wayland display servers.
  */
 class MainThreadClipboard : MainThreadClipboardShape {
     private val logger = Logger.getInstance(MainThreadClipboardShape::class.java)
+    private val isWayland = System.getenv("WAYLAND_DISPLAY") != null || 
+                            System.getenv("XDG_SESSION_TYPE") == "wayland"
 
     /**
      * Reads text from the system clipboard.
+     * Uses IntelliJ's CopyPasteManager for better compatibility with Wayland.
      *
      * @return The string from the clipboard, or null if no text is available or an error occurs
      */
     override fun readText(): String? {
-        logger.info("Reading clipboard text")
+        logger.info("Reading clipboard text (Wayland: $isWayland)")
+        
+        // Try using IntelliJ's CopyPasteManager first for better Wayland support
+        return try {
+            val contents = CopyPasteManager.getInstance().contents
+            if (contents != null && contents.isDataFlavorSupported(DataFlavor.stringFlavor)) {
+                contents.getTransferData(DataFlavor.stringFlavor) as? String
+            } else {
+                // Fallback to AWT Toolkit
+                readTextWithAWT()
+            }
+        } catch (e: Exception) {
+            logger.warn("Failed to read clipboard with CopyPasteManager, trying AWT", e)
+            readTextWithAWT()
+        }
+    }
+    
+    /**
+     * Fallback method to read text using AWT Toolkit.
+     */
+    private fun readTextWithAWT(): String? {
         return try {
             val clipboard = Toolkit.getDefaultToolkit().systemClipboard
             val data = clipboard.getContents(null)
@@ -51,26 +78,42 @@ class MainThreadClipboard : MainThreadClipboardShape {
                 null
             }
         } catch (e: Exception) {
-            logger.error("Failed to read clipboard", e)
+            logger.error("Failed to read clipboard with AWT", e)
             null
         }
     }
 
     /**
      * Writes text to the system clipboard.
+     * Uses IntelliJ's CopyPasteManager for better compatibility with Wayland.
      *
      * @param value The string to write to the clipboard
      */
     override fun writeText(value: String?) {
         value?.let {
-            logger.info("Writing clipboard text: $value")
+            logger.info("Writing clipboard text (Wayland: $isWayland)")
+            val selection = StringSelection(value)
+            
+            // Try using IntelliJ's CopyPasteManager first for better Wayland support
             try {
-                val clipboard = Toolkit.getDefaultToolkit().systemClipboard
-                val selection = StringSelection(value)
-                clipboard.setContents(selection, selection)
+                CopyPasteManager.getInstance().setContents(selection)
             } catch (e: Exception) {
-                logger.error("Failed to write to clipboard", e)
+                logger.warn("Failed to write to clipboard with CopyPasteManager, trying AWT", e)
+                // Fallback to AWT Toolkit
+                writeTextWithAWT(selection)
             }
+        }
+    }
+    
+    /**
+     * Fallback method to write text using AWT Toolkit.
+     */
+    private fun writeTextWithAWT(selection: StringSelection) {
+        try {
+            val clipboard = Toolkit.getDefaultToolkit().systemClipboard
+            clipboard.setContents(selection, EmptyClipboardOwner.INSTANCE)
+        } catch (e: Exception) {
+            logger.error("Failed to write to clipboard with AWT", e)
         }
     }
 

--- a/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/webview/WaylandClipboardHandler.kt
+++ b/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/webview/WaylandClipboardHandler.kt
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package com.sina.weibo.agent.webview
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.ide.CopyPasteManager
+import org.cef.browser.CefBrowser
+import org.cef.browser.CefFrame
+import org.cef.callback.CefContextMenuParams
+import org.cef.callback.CefMenuModel
+import org.cef.handler.CefContextMenuHandler
+import org.cef.handler.CefKeyboardHandler
+import org.cef.handler.CefKeyboardHandlerAdapter
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
+
+/**
+ * Wayland-compatible clipboard handler for WebView.
+ * Handles clipboard operations for JCEF WebView on both X11 and Wayland.
+ */
+class WaylandClipboardHandler : CefKeyboardHandlerAdapter() {
+    private val logger = Logger.getInstance(WaylandClipboardHandler::class.java)
+    private val isWayland = System.getenv("WAYLAND_DISPLAY") != null ||
+                           System.getenv("XDG_SESSION_TYPE") == "wayland"
+
+    /**
+     * Handle keyboard events for clipboard operations.
+     */
+    override fun onPreKeyEvent(
+        browser: CefBrowser?,
+        event: org.cef.handler.CefKeyboardHandler.CefKeyEvent?,
+        is_keyboard_shortcut: org.cef.misc.BoolRef?
+    ): Boolean {
+        if (event == null || browser == null) return false
+        
+        // Check for paste shortcut (Ctrl+V or Cmd+V)
+        val isPasteShortcut = when {
+            // Windows/Linux: Ctrl+V
+            (event.modifiers and EVENTFLAG_CONTROL_DOWN != 0) && event.windows_key_code == 86 -> true
+            // macOS: Cmd+V
+            (event.modifiers and EVENTFLAG_COMMAND_DOWN != 0) && event.windows_key_code == 86 -> true
+            else -> false
+        }
+        
+        // Check for copy shortcut (Ctrl+C or Cmd+C)
+        val isCopyShortcut = when {
+            // Windows/Linux: Ctrl+C
+            (event.modifiers and EVENTFLAG_CONTROL_DOWN != 0) && event.windows_key_code == 67 -> true
+            // macOS: Cmd+C
+            (event.modifiers and EVENTFLAG_COMMAND_DOWN != 0) && event.windows_key_code == 67 -> true
+            else -> false
+        }
+        
+        // Check for cut shortcut (Ctrl+X or Cmd+X)
+        val isCutShortcut = when {
+            // Windows/Linux: Ctrl+X
+            (event.modifiers and EVENTFLAG_CONTROL_DOWN != 0) && event.windows_key_code == 88 -> true
+            // macOS: Cmd+X
+            (event.modifiers and EVENTFLAG_COMMAND_DOWN != 0) && event.windows_key_code == 88 -> true
+            else -> false
+        }
+        
+        if (isPasteShortcut && event.type == EventType.KEYEVENT_RAWKEYDOWN) {
+            handlePaste(browser)
+            return true // Consume the event
+        }
+        
+        if (isCopyShortcut && event.type == EventType.KEYEVENT_RAWKEYDOWN) {
+            handleCopy(browser)
+            return true // Consume the event
+        }
+        
+        if (isCutShortcut && event.type == EventType.KEYEVENT_RAWKEYDOWN) {
+            handleCut(browser)
+            return true // Consume the event
+        }
+        
+        return false
+    }
+    
+    /**
+     * Handle paste operation using IntelliJ's CopyPasteManager.
+     */
+    private fun handlePaste(browser: CefBrowser) {
+        try {
+            logger.info("Handling paste operation (Wayland: $isWayland)")
+            
+            // Get clipboard content using IntelliJ's CopyPasteManager
+            val contents = CopyPasteManager.getInstance().contents
+            if (contents != null && contents.isDataFlavorSupported(DataFlavor.stringFlavor)) {
+                val text = contents.getTransferData(DataFlavor.stringFlavor) as? String
+                text?.let {
+                    // Execute paste in the browser
+                    browser.executeJavaScript(
+                        """
+                        (function() {
+                            const activeElement = document.activeElement;
+                            if (activeElement && (activeElement.tagName === 'INPUT' || 
+                                activeElement.tagName === 'TEXTAREA' || 
+                                activeElement.contentEditable === 'true')) {
+                                
+                                // For input and textarea elements
+                                if (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA') {
+                                    const start = activeElement.selectionStart;
+                                    const end = activeElement.selectionEnd;
+                                    const value = activeElement.value;
+                                    const textToInsert = ${text.toJsString()};
+                                    activeElement.value = value.substring(0, start) + textToInsert + value.substring(end);
+                                    activeElement.selectionStart = activeElement.selectionEnd = start + textToInsert.length;
+                                    
+                                    // Trigger input event
+                                    activeElement.dispatchEvent(new Event('input', { bubbles: true }));
+                                    activeElement.dispatchEvent(new Event('change', { bubbles: true }));
+                                }
+                                // For contentEditable elements
+                                else if (activeElement.contentEditable === 'true') {
+                                    document.execCommand('insertText', false, ${text.toJsString()});
+                                }
+                            }
+                        })();
+                        """.trimIndent(),
+                        browser.url,
+                        0
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            logger.error("Failed to handle paste operation", e)
+        }
+    }
+    
+    /**
+     * Handle copy operation.
+     */
+    private fun handleCopy(browser: CefBrowser) {
+        try {
+            logger.info("Handling copy operation (Wayland: $isWayland)")
+            
+            // Get selected text from the browser
+            browser.executeJavaScript(
+                """
+                (function() {
+                    const selection = window.getSelection().toString();
+                    if (selection) {
+                        // Send selected text back to Java
+                        window.cefQuery({
+                            request: JSON.stringify({
+                                type: 'clipboard-copy',
+                                text: selection
+                            }),
+                            onSuccess: function(response) {},
+                            onFailure: function(error_code, error_message) {}
+                        });
+                    }
+                })();
+                """.trimIndent(),
+                browser.url,
+                0
+            )
+        } catch (e: Exception) {
+            logger.error("Failed to handle copy operation", e)
+        }
+    }
+    
+    /**
+     * Handle cut operation.
+     */
+    private fun handleCut(browser: CefBrowser) {
+        try {
+            logger.info("Handling cut operation (Wayland: $isWayland)")
+            
+            // Get selected text and remove it
+            browser.executeJavaScript(
+                """
+                (function() {
+                    const selection = window.getSelection().toString();
+                    if (selection) {
+                        // Send selected text back to Java
+                        window.cefQuery({
+                            request: JSON.stringify({
+                                type: 'clipboard-cut',
+                                text: selection
+                            }),
+                            onSuccess: function(response) {},
+                            onFailure: function(error_code, error_message) {}
+                        });
+                        
+                        // Remove selected text
+                        document.execCommand('delete', false, null);
+                    }
+                })();
+                """.trimIndent(),
+                browser.url,
+                0
+            )
+        } catch (e: Exception) {
+            logger.error("Failed to handle cut operation", e)
+        }
+    }
+    
+    /**
+     * Copy text to clipboard using IntelliJ's CopyPasteManager.
+     */
+    fun copyToClipboard(text: String) {
+        try {
+            val selection = StringSelection(text)
+            CopyPasteManager.getInstance().setContents(selection)
+            logger.info("Text copied to clipboard")
+        } catch (e: Exception) {
+            logger.error("Failed to copy to clipboard", e)
+        }
+    }
+    
+    companion object {
+        // CEF keyboard event flags
+        private const val EVENTFLAG_CONTROL_DOWN = 1 shl 7
+        private const val EVENTFLAG_COMMAND_DOWN = 1 shl 8
+        
+        // CEF key event types
+        private object EventType {
+            const val KEYEVENT_RAWKEYDOWN = 0
+            const val KEYEVENT_KEYDOWN = 1
+            const val KEYEVENT_KEYUP = 2
+            const val KEYEVENT_CHAR = 3
+        }
+    }
+}
+
+/**
+ * Extension function to escape string for JavaScript.
+ */
+private fun String.toJsString(): String {
+    return "'" + this
+        .replace("\\", "\\\\")
+        .replace("'", "\\'")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t") + "'"
+}

--- a/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/webview/WebViewManager.kt
+++ b/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/webview/WebViewManager.kt
@@ -486,6 +486,8 @@ class WebViewInstance(
         setupJSBridge()
         // Enable resource loading interception
         enableResourceInterception(extension)
+        // Setup Wayland-compatible clipboard handler
+        setupClipboardHandler()
     }
 
     /**
@@ -732,6 +734,23 @@ class WebViewInstance(
         }
     }
 
+    /**
+     * Setup Wayland-compatible clipboard handler for WebView.
+     */
+    private fun setupClipboardHandler() {
+        try {
+            val clipboardHandler = WaylandClipboardHandler()
+            val client = browser.jbCefClient
+            
+            // Add keyboard handler for clipboard shortcuts
+            client.addKeyboardHandler(clipboardHandler, browser.cefBrowser)
+            
+            logger.info("Wayland clipboard handler setup completed")
+        } catch (e: Exception) {
+            logger.error("Failed to setup clipboard handler", e)
+        }
+    }
+    
     private fun setupJSBridge() {
         // Create JS query object to handle messages from webview
         jsQuery = JBCefJSQuery.create(browser)
@@ -739,7 +758,28 @@ class WebViewInstance(
         // Set callback for receiving messages from webview
         jsQuery?.addHandler { message ->
             coroutineScope.launch {
-                // Handle message
+                // Check if this is a clipboard-related message
+                try {
+                    val messageObj = gson.fromJson(message, JsonObject::class.java)
+                    val messageType = messageObj.get("type")?.asString
+                    
+                    when (messageType) {
+                        "clipboard-copy", "clipboard-cut" -> {
+                            // Handle clipboard copy/cut operations
+                            val text = messageObj.get("text")?.asString
+                            if (text != null) {
+                                val clipboardHandler = WaylandClipboardHandler()
+                                clipboardHandler.copyToClipboard(text)
+                                logger.info("Clipboard operation handled: $messageType")
+                            }
+                            return@launch
+                        }
+                    }
+                } catch (e: Exception) {
+                    // Not a JSON message or doesn't have expected structure, proceed normally
+                }
+                
+                // Handle regular message
                 val protocol = project.getService(PluginContext::class.java).getRPCProtocol()
                 if (protocol != null) {
                     // Send message to plugin host

--- a/jetbrains_plugin/src/test/kotlin/com/sina/weibo/agent/actors/MainThreadClipboardShapeTest.kt
+++ b/jetbrains_plugin/src/test/kotlin/com/sina/weibo/agent/actors/MainThreadClipboardShapeTest.kt
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package com.sina.weibo.agent.actors
+
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import java.awt.Toolkit
+import java.awt.datatransfer.Clipboard
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
+
+/**
+ * Unit tests for MainThreadClipboardShape functionality with Wayland support.
+ */
+class MainThreadClipboardShapeTest : BasePlatformTestCase() {
+
+    private lateinit var clipboard: MainThreadClipboard
+    private val mockCopyPasteManager: CopyPasteManager = mockk()
+    private val mockSystemClipboard: Clipboard = mockk()
+    private val mockTransferable: Transferable = mockk()
+
+    override fun setUp() {
+        super.setUp()
+        clipboard = MainThreadClipboard()
+        
+        // Mock static methods
+        mockkStatic(CopyPasteManager::class)
+        mockkStatic(Toolkit::class)
+        
+        every { CopyPasteManager.getInstance() } returns mockCopyPasteManager
+        every { Toolkit.getDefaultToolkit().systemClipboard } returns mockSystemClipboard
+    }
+
+    fun testEnvironmentDetection() {
+        // Test Wayland environment detection
+        mockkStatic(System::class)
+        
+        // Test WAYLAND_DISPLAY environment variable
+        every { System.getenv("WAYLAND_DISPLAY") } returns "wayland-0"
+        every { System.getenv("XDG_SESSION_TYPE") } returns null
+        
+        val waylandClipboard = MainThreadClipboard()
+        assertNotNull("Clipboard should be created for Wayland environment", waylandClipboard)
+        
+        // Test XDG_SESSION_TYPE environment variable
+        every { System.getenv("WAYLAND_DISPLAY") } returns null
+        every { System.getenv("XDG_SESSION_TYPE") } returns "wayland"
+        
+        val waylandClipboard2 = MainThreadClipboard()
+        assertNotNull("Clipboard should be created for Wayland environment via XDG_SESSION_TYPE", waylandClipboard2)
+        
+        // Test X11 environment (no Wayland variables)
+        every { System.getenv("WAYLAND_DISPLAY") } returns null
+        every { System.getenv("XDG_SESSION_TYPE") } returns "x11"
+        
+        val x11Clipboard = MainThreadClipboard()
+        assertNotNull("Clipboard should be created for X11 environment", x11Clipboard)
+    }
+
+    fun testReadTextWithCopyPasteManager() {
+        // Test successful read using CopyPasteManager
+        val expectedText = "test clipboard content"
+        
+        every { mockCopyPasteManager.contents } returns mockTransferable
+        every { mockTransferable.isDataFlavorSupported(DataFlavor.stringFlavor) } returns true
+        every { mockTransferable.getTransferData(DataFlavor.stringFlavor) } returns expectedText
+        
+        val result = clipboard.readText()
+        
+        assertEquals("Should return text from CopyPasteManager", expectedText, result)
+        verify { mockCopyPasteManager.contents }
+        verify { mockTransferable.getTransferData(DataFlavor.stringFlavor) }
+    }
+
+    fun testReadTextWithAWTFallback() {
+        // Test fallback to AWT when CopyPasteManager fails
+        val expectedText = "awt fallback text"
+        
+        // Mock CopyPasteManager to throw exception
+        every { mockCopyPasteManager.contents } throws RuntimeException("CopyPasteManager failed")
+        
+        // Mock AWT clipboard success
+        every { mockSystemClipboard.getContents(null) } returns mockTransferable
+        every { mockTransferable.isDataFlavorSupported(DataFlavor.stringFlavor) } returns true
+        every { mockTransferable.getTransferData(DataFlavor.stringFlavor) } returns expectedText
+        
+        val result = clipboard.readText()
+        
+        assertEquals("Should return text from AWT fallback", expectedText, result)
+        verify { mockSystemClipboard.getContents(null) }
+    }
+
+    fun testReadTextReturnsNullWhenNoTextAvailable() {
+        // Test when no text is available in clipboard
+        every { mockCopyPasteManager.contents } returns mockTransferable
+        every { mockTransferable.isDataFlavorSupported(DataFlavor.stringFlavor) } returns false
+        
+        // Mock AWT fallback also returns no text
+        every { mockSystemClipboard.getContents(null) } returns mockTransferable
+        
+        val result = clipboard.readText()
+        
+        assertNull("Should return null when no text is available", result)
+    }
+
+    fun testReadTextHandlesException() {
+        // Test exception handling when both CopyPasteManager and AWT fail
+        every { mockCopyPasteManager.contents } throws RuntimeException("CopyPasteManager failed")
+        every { mockSystemClipboard.getContents(null) } throws RuntimeException("AWT failed")
+        
+        val result = clipboard.readText()
+        
+        assertNull("Should return null when both clipboard methods fail", result)
+    }
+
+    fun testWriteTextWithCopyPasteManager() {
+        // Test successful write using CopyPasteManager
+        val textToWrite = "test write content"
+        
+        every { mockCopyPasteManager.setContents(any()) } returns Unit
+        
+        clipboard.writeText(textToWrite)
+        
+        verify { mockCopyPasteManager.setContents(any<StringSelection>()) }
+    }
+
+    fun testWriteTextWithAWTFallback() {
+        // Test fallback to AWT when CopyPasteManager fails
+        val textToWrite = "awt fallback write"
+        
+        // Mock CopyPasteManager to throw exception
+        every { mockCopyPasteManager.setContents(any()) } throws RuntimeException("CopyPasteManager failed")
+        
+        // Mock AWT success
+        every { mockSystemClipboard.setContents(any(), any()) } returns Unit
+        
+        clipboard.writeText(textToWrite)
+        
+        verify { mockSystemClipboard.setContents(any<StringSelection>(), any()) }
+    }
+
+    fun testWriteTextHandlesNullValue() {
+        // Test writing null value does nothing
+        clipboard.writeText(null)
+        
+        // Verify no interactions with clipboard
+        verify(exactly = 0) { mockCopyPasteManager.setContents(any()) }
+        verify(exactly = 0) { mockSystemClipboard.setContents(any(), any()) }
+    }
+
+    fun testWriteTextHandlesEmptyString() {
+        // Test writing empty string
+        val emptyText = ""
+        
+        every { mockCopyPasteManager.setContents(any()) } returns Unit
+        
+        clipboard.writeText(emptyText)
+        
+        verify { mockCopyPasteManager.setContents(any<StringSelection>()) }
+    }
+
+    fun testWriteTextHandlesException() {
+        // Test exception handling when both CopyPasteManager and AWT fail
+        val textToWrite = "test exception"
+        
+        every { mockCopyPasteManager.setContents(any()) } throws RuntimeException("CopyPasteManager failed")
+        every { mockSystemClipboard.setContents(any(), any()) } throws RuntimeException("AWT failed")
+        
+        // Should not throw exception
+        clipboard.writeText(textToWrite)
+        
+        verify { mockCopyPasteManager.setContents(any<StringSelection>()) }
+        verify { mockSystemClipboard.setContents(any<StringSelection>(), any()) }
+    }
+
+    fun testDispose() {
+        // Test disposal of clipboard resources
+        assertDoesNotThrow("Dispose should not throw exception") {
+            clipboard.dispose()
+        }
+    }
+
+    fun testClipboardInterface() {
+        // Test that MainThreadClipboard implements the interface correctly
+        assertTrue("Should implement MainThreadClipboardShape", clipboard is MainThreadClipboardShape)
+        assertTrue("Should implement Disposable", clipboard is com.intellij.openapi.Disposable)
+    }
+
+    fun testReadWriteRoundTrip() {
+        // Test reading back what was written
+        val testText = "round trip test"
+        
+        every { mockCopyPasteManager.setContents(any()) } returns Unit
+        every { mockCopyPasteManager.contents } returns mockTransferable
+        every { mockTransferable.isDataFlavorSupported(DataFlavor.stringFlavor) } returns true
+        every { mockTransferable.getTransferData(DataFlavor.stringFlavor) } returns testText
+        
+        clipboard.writeText(testText)
+        val readText = clipboard.readText()
+        
+        assertEquals("Read text should match written text", testText, readText)
+    }
+
+    fun testLargeTextHandling() {
+        // Test handling of large text content
+        val largeText = "x".repeat(10000)
+        
+        every { mockCopyPasteManager.setContents(any()) } returns Unit
+        every { mockCopyPasteManager.contents } returns mockTransferable
+        every { mockTransferable.isDataFlavorSupported(DataFlavor.stringFlavor) } returns true
+        every { mockTransferable.getTransferData(DataFlavor.stringFlavor) } returns largeText
+        
+        clipboard.writeText(largeText)
+        val readText = clipboard.readText()
+        
+        assertEquals("Should handle large text content", largeText, readText)
+    }
+
+    fun testSpecialCharacterHandling() {
+        // Test handling of special characters
+        val specialText = "Test with special chars: \n\t\r🚀💻📝"
+        
+        every { mockCopyPasteManager.setContents(any()) } returns Unit
+        every { mockCopyPasteManager.contents } returns mockTransferable
+        every { mockTransferable.isDataFlavorSupported(DataFlavor.stringFlavor) } returns true
+        every { mockTransferable.getTransferData(DataFlavor.stringFlavor) } returns specialText
+        
+        clipboard.writeText(specialText)
+        val readText = clipboard.readText()
+        
+        assertEquals("Should handle special characters", specialText, readText)
+    }
+}

--- a/jetbrains_plugin/src/test/kotlin/com/sina/weibo/agent/webview/WaylandClipboardHandlerTest.kt
+++ b/jetbrains_plugin/src/test/kotlin/com/sina/weibo/agent/webview/WaylandClipboardHandlerTest.kt
@@ -1,0 +1,331 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package com.sina.weibo.agent.webview
+
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.verify
+import org.cef.browser.CefBrowser
+import org.cef.handler.CefKeyboardHandler
+import org.cef.misc.BoolRef
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
+
+/**
+ * Unit tests for WaylandClipboardHandler functionality.
+ */
+class WaylandClipboardHandlerTest : BasePlatformTestCase() {
+
+    private lateinit var clipboardHandler: WaylandClipboardHandler
+    private val mockBrowser: CefBrowser = mockk()
+    private val mockCopyPasteManager: CopyPasteManager = mockk()
+    private val mockTransferable: Transferable = mockk()
+
+    override fun setUp() {
+        super.setUp()
+        clipboardHandler = WaylandClipboardHandler()
+        
+        // Mock static methods
+        mockkStatic(CopyPasteManager::class)
+        every { CopyPasteManager.getInstance() } returns mockCopyPasteManager
+    }
+
+    fun testEnvironmentDetection() {
+        // Test Wayland environment detection in handler
+        mockkStatic(System::class)
+        
+        // Test WAYLAND_DISPLAY environment variable
+        every { System.getenv("WAYLAND_DISPLAY") } returns "wayland-0"
+        every { System.getenv("XDG_SESSION_TYPE") } returns null
+        
+        val waylandHandler = WaylandClipboardHandler()
+        assertNotNull("Handler should be created for Wayland environment", waylandHandler)
+        
+        // Test X11 environment
+        every { System.getenv("WAYLAND_DISPLAY") } returns null
+        every { System.getenv("XDG_SESSION_TYPE") } returns "x11"
+        
+        val x11Handler = WaylandClipboardHandler()
+        assertNotNull("Handler should be created for X11 environment", x11Handler)
+    }
+
+    fun testPasteShortcutDetection() {
+        // Test Ctrl+V detection (Windows/Linux)
+        val pasteEvent = createKeyEvent(
+            type = 0, // KEYEVENT_RAWKEYDOWN
+            modifiers = 1 shl 7, // EVENTFLAG_CONTROL_DOWN
+            windowsKeyCode = 86 // V key
+        )
+        
+        every { mockBrowser.executeJavaScript(any<String>(), any<String>(), any<Int>()) } returns Unit
+        every { mockCopyPasteManager.contents } returns mockTransferable
+        every { mockTransferable.isDataFlavorSupported(DataFlavor.stringFlavor) } returns true
+        every { mockTransferable.getTransferData(DataFlavor.stringFlavor) } returns "test paste"
+        
+        val result = clipboardHandler.onPreKeyEvent(mockBrowser, pasteEvent, BoolRef())
+        
+        assertTrue("Should handle paste shortcut", result)
+        verify { mockBrowser.executeJavaScript(any<String>(), any<String>(), any<Int>()) }
+    }
+
+    fun testCopyShortcutDetection() {
+        // Test Ctrl+C detection (Windows/Linux)
+        val copyEvent = createKeyEvent(
+            type = 0, // KEYEVENT_RAWKEYDOWN
+            modifiers = 1 shl 7, // EVENTFLAG_CONTROL_DOWN
+            windowsKeyCode = 67 // C key
+        )
+        
+        every { mockBrowser.executeJavaScript(any<String>(), any<String>(), any<Int>()) } returns Unit
+        
+        val result = clipboardHandler.onPreKeyEvent(mockBrowser, copyEvent, BoolRef())
+        
+        assertTrue("Should handle copy shortcut", result)
+        verify { mockBrowser.executeJavaScript(any<String>(), any<String>(), any<Int>()) }
+    }
+
+    fun testCutShortcutDetection() {
+        // Test Ctrl+X detection (Windows/Linux)
+        val cutEvent = createKeyEvent(
+            type = 0, // KEYEVENT_RAWKEYDOWN
+            modifiers = 1 shl 7, // EVENTFLAG_CONTROL_DOWN
+            windowsKeyCode = 88 // X key
+        )
+        
+        every { mockBrowser.executeJavaScript(any<String>(), any<String>(), any<Int>()) } returns Unit
+        
+        val result = clipboardHandler.onPreKeyEvent(mockBrowser, cutEvent, BoolRef())
+        
+        assertTrue("Should handle cut shortcut", result)
+        verify { mockBrowser.executeJavaScript(any<String>(), any<String>(), any<Int>()) }
+    }
+
+    fun testMacPasteShortcutDetection() {
+        // Test Cmd+V detection (macOS)
+        val cmdPasteEvent = createKeyEvent(
+            type = 0, // KEYEVENT_RAWKEYDOWN
+            modifiers = 1 shl 8, // EVENTFLAG_COMMAND_DOWN
+            windowsKeyCode = 86 // V key
+        )
+        
+        every { mockBrowser.executeJavaScript(any<String>(), any<String>(), any<Int>()) } returns Unit
+        every { mockCopyPasteManager.contents } returns mockTransferable
+        every { mockTransferable.isDataFlavorSupported(DataFlavor.stringFlavor) } returns true
+        every { mockTransferable.getTransferData(DataFlavor.stringFlavor) } returns "mac paste"
+        
+        val result = clipboardHandler.onPreKeyEvent(mockBrowser, cmdPasteEvent, BoolRef())
+        
+        assertTrue("Should handle Mac paste shortcut", result)
+    }
+
+    fun testNonShortcutKeyEvents() {
+        // Test that non-shortcut keys are not handled
+        val normalEvent = createKeyEvent(
+            type = 0, // KEYEVENT_RAWKEYDOWN
+            modifiers = 0, // No modifiers
+            windowsKeyCode = 65 // A key
+        )
+        
+        val result = clipboardHandler.onPreKeyEvent(mockBrowser, normalEvent, BoolRef())
+        
+        assertFalse("Should not handle normal key events", result)
+    }
+
+    fun testKeyUpEventsIgnored() {
+        // Test that key up events are ignored for shortcuts
+        val keyUpEvent = createKeyEvent(
+            type = 2, // KEYEVENT_KEYUP
+            modifiers = 1 shl 7, // EVENTFLAG_CONTROL_DOWN
+            windowsKeyCode = 86 // V key
+        )
+        
+        val result = clipboardHandler.onPreKeyEvent(mockBrowser, keyUpEvent, BoolRef())
+        
+        assertFalse("Should ignore key up events", result)
+    }
+
+    fun testPasteWithEmptyClipboard() {
+        // Test paste when clipboard is empty
+        val pasteEvent = createKeyEvent(
+            type = 0, // KEYEVENT_RAWKEYDOWN
+            modifiers = 1 shl 7, // EVENTFLAG_CONTROL_DOWN
+            windowsKeyCode = 86 // V key
+        )
+        
+        every { mockCopyPasteManager.contents } returns null
+        
+        val result = clipboardHandler.onPreKeyEvent(mockBrowser, pasteEvent, BoolRef())
+        
+        assertTrue("Should handle paste event even with empty clipboard", result)
+        // Should not execute JavaScript when clipboard is empty
+        verify(exactly = 0) { mockBrowser.executeJavaScript(any<String>(), any<String>(), any<Int>()) }
+    }
+
+    fun testPasteWithUnsupportedDataFlavor() {
+        // Test paste when clipboard doesn't support string flavor
+        val pasteEvent = createKeyEvent(
+            type = 0, // KEYEVENT_RAWKEYDOWN
+            modifiers = 1 shl 7, // EVENTFLAG_CONTROL_DOWN
+            windowsKeyCode = 86 // V key
+        )
+        
+        every { mockCopyPasteManager.contents } returns mockTransferable
+        every { mockTransferable.isDataFlavorSupported(DataFlavor.stringFlavor) } returns false
+        
+        val result = clipboardHandler.onPreKeyEvent(mockBrowser, pasteEvent, BoolRef())
+        
+        assertTrue("Should handle paste event even with unsupported data flavor", result)
+        verify(exactly = 0) { mockBrowser.executeJavaScript(any<String>(), any<String>(), any<Int>()) }
+    }
+
+    fun testPasteJavaScriptInjection() {
+        // Test that paste injects correct JavaScript
+        val pasteEvent = createKeyEvent(
+            type = 0, // KEYEVENT_RAWKEYDOWN
+            modifiers = 1 shl 7, // EVENTFLAG_CONTROL_DOWN
+            windowsKeyCode = 86 // V key
+        )
+        
+        val testText = "Test paste content"
+        val jsCodeSlot = slot<String>()
+        
+        every { mockBrowser.executeJavaScript(capture(jsCodeSlot), any<String>(), any<Int>()) } returns Unit
+        every { mockCopyPasteManager.contents } returns mockTransferable
+        every { mockTransferable.isDataFlavorSupported(DataFlavor.stringFlavor) } returns true
+        every { mockTransferable.getTransferData(DataFlavor.stringFlavor) } returns testText
+        
+        clipboardHandler.onPreKeyEvent(mockBrowser, pasteEvent, BoolRef())
+        
+        val capturedJs = jsCodeSlot.captured
+        assertTrue("JavaScript should handle input elements", capturedJs.contains("INPUT"))
+        assertTrue("JavaScript should handle textarea elements", capturedJs.contains("TEXTAREA"))
+        assertTrue("JavaScript should handle contentEditable", capturedJs.contains("contentEditable"))
+        assertTrue("JavaScript should trigger input event", capturedJs.contains("dispatchEvent"))
+    }
+
+    fun testCopyToClipboard() {
+        // Test copying text to clipboard
+        val testText = "Test copy content"
+        
+        every { mockCopyPasteManager.setContents(any()) } returns Unit
+        
+        clipboardHandler.copyToClipboard(testText)
+        
+        verify { mockCopyPasteManager.setContents(any<StringSelection>()) }
+    }
+
+    fun testCopyToClipboardHandlesException() {
+        // Test exception handling in copyToClipboard
+        val testText = "Test exception handling"
+        
+        every { mockCopyPasteManager.setContents(any()) } throws RuntimeException("Mock exception")
+        
+        // Should not throw exception
+        assertDoesNotThrow("copyToClipboard should handle exceptions gracefully") {
+            clipboardHandler.copyToClipboard(testText)
+        }
+    }
+
+    fun testStringToJsStringEscaping() {
+        // Test JavaScript string escaping functionality
+        val handler = WaylandClipboardHandler()
+        
+        // Use reflection to access private toJsString extension function
+        val testCases = mapOf(
+            "simple text" to "'simple text'",
+            "text with 'quotes'" to "'text with \\'quotes\\''",
+            "text with\nnewlines" to "'text with\\nlines'",
+            "text with\ttabs" to "'text with\\ttabs'",
+            "text with\\backslashes" to "'text with\\\\backslashes'"
+        )
+        
+        // Since toJsString is private, we test it indirectly through paste operation
+        testCases.forEach { (input, _) ->
+            val pasteEvent = createKeyEvent(
+                type = 0, // KEYEVENT_RAWKEYDOWN
+                modifiers = 1 shl 7, // EVENTFLAG_CONTROL_DOWN
+                windowsKeyCode = 86 // V key
+            )
+            
+            val jsCodeSlot = slot<String>()
+            every { mockBrowser.executeJavaScript(capture(jsCodeSlot), any<String>(), any<Int>()) } returns Unit
+            every { mockCopyPasteManager.contents } returns mockTransferable
+            every { mockTransferable.isDataFlavorSupported(DataFlavor.stringFlavor) } returns true
+            every { mockTransferable.getTransferData(DataFlavor.stringFlavor) } returns input
+            
+            handler.onPreKeyEvent(mockBrowser, pasteEvent, BoolRef())
+            
+            val capturedJs = jsCodeSlot.captured
+            assertNotNull("JavaScript should be generated for special characters", capturedJs)
+            // Verify that special characters are properly escaped
+            assertFalse("JavaScript should not contain unescaped quotes", capturedJs.contains("'$input'"))
+        }
+    }
+
+    fun testNullEventHandling() {
+        // Test handling of null events
+        val result = clipboardHandler.onPreKeyEvent(mockBrowser, null, BoolRef())
+        assertFalse("Should return false for null event", result)
+        
+        val result2 = clipboardHandler.onPreKeyEvent(null, createKeyEvent(0, 0, 0), BoolRef())
+        assertFalse("Should return false for null browser", result2)
+    }
+
+    fun testCopyJavaScriptGeneration() {
+        // Test that copy operation generates correct JavaScript
+        val copyEvent = createKeyEvent(
+            type = 0, // KEYEVENT_RAWKEYDOWN
+            modifiers = 1 shl 7, // EVENTFLAG_CONTROL_DOWN
+            windowsKeyCode = 67 // C key
+        )
+        
+        val jsCodeSlot = slot<String>()
+        every { mockBrowser.executeJavaScript(capture(jsCodeSlot), any<String>(), any<Int>()) } returns Unit
+        
+        clipboardHandler.onPreKeyEvent(mockBrowser, copyEvent, BoolRef())
+        
+        val capturedJs = jsCodeSlot.captured
+        assertTrue("JavaScript should get selection", capturedJs.contains("getSelection"))
+        assertTrue("JavaScript should use cefQuery", capturedJs.contains("cefQuery"))
+        assertTrue("JavaScript should send clipboard-copy message", capturedJs.contains("clipboard-copy"))
+    }
+
+    fun testCutJavaScriptGeneration() {
+        // Test that cut operation generates correct JavaScript
+        val cutEvent = createKeyEvent(
+            type = 0, // KEYEVENT_RAWKEYDOWN
+            modifiers = 1 shl 7, // EVENTFLAG_CONTROL_DOWN
+            windowsKeyCode = 88 // X key
+        )
+        
+        val jsCodeSlot = slot<String>()
+        every { mockBrowser.executeJavaScript(capture(jsCodeSlot), any<String>(), any<Int>()) } returns Unit
+        
+        clipboardHandler.onPreKeyEvent(mockBrowser, cutEvent, BoolRef())
+        
+        val capturedJs = jsCodeSlot.captured
+        assertTrue("JavaScript should get selection", capturedJs.contains("getSelection"))
+        assertTrue("JavaScript should use cefQuery", capturedJs.contains("cefQuery"))
+        assertTrue("JavaScript should send clipboard-cut message", capturedJs.contains("clipboard-cut"))
+        assertTrue("JavaScript should delete selection", capturedJs.contains("execCommand('delete'"))
+    }
+
+    private fun createKeyEvent(
+        type: Int,
+        modifiers: Int,
+        windowsKeyCode: Int
+    ): CefKeyboardHandler.CefKeyEvent {
+        return mockk<CefKeyboardHandler.CefKeyEvent>().apply {
+            every { this@apply.type } returns type
+            every { this@apply.modifiers } returns modifiers
+            every { this@apply.windows_key_code } returns windowsKeyCode
+        }
+    }
+}

--- a/jetbrains_plugin/src/test/kotlin/com/sina/weibo/agent/webview/WebViewManagerClipboardTest.kt
+++ b/jetbrains_plugin/src/test/kotlin/com/sina/weibo/agent/webview/WebViewManagerClipboardTest.kt
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package com.sina.weibo.agent.webview
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.sina.weibo.agent.plugin.PluginContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.concurrency.Promise
+import org.junit.Test
+
+/**
+ * Unit tests for WebViewManager clipboard-related functionality.
+ * Tests the integration of WaylandClipboardHandler with WebViewManager.
+ */
+class WebViewManagerClipboardTest : BasePlatformTestCase() {
+
+    private val gson = Gson()
+    private lateinit var mockProject: Project
+    private lateinit var mockPluginContext: PluginContext
+
+    override fun setUp() {
+        super.setUp()
+        mockProject = project
+        mockPluginContext = mockk()
+        
+        // Mock the project service
+        mockkStatic("com.intellij.openapi.components.ComponentManagerKt")
+        every { mockProject.getService(PluginContext::class.java) } returns mockPluginContext
+        every { mockPluginContext.getRPCProtocol() } returns null
+    }
+
+    @Test
+    fun testClipboardCopyMessageHandling() = runTest {
+        // Test handling of clipboard-copy messages
+        val copyMessage = JsonObject().apply {
+            addProperty("type", "clipboard-copy")
+            addProperty("text", "Test copy content")
+        }
+        
+        val messageJson = gson.toJson(copyMessage)
+        
+        // Create a spy of WaylandClipboardHandler to verify interaction
+        val clipboardHandlerSpy = spyk<WaylandClipboardHandler>()
+        
+        // Mock the clipboard handler creation
+        mockkStatic(WaylandClipboardHandler::class)
+        every { WaylandClipboardHandler() } returns clipboardHandlerSpy
+        every { clipboardHandlerSpy.copyToClipboard(any()) } returns Unit
+        
+        // Since we can't easily test the private setupJSBridge method directly,
+        // we test the message handling logic by simulating what happens
+        // when a clipboard message is received
+        val handledMessage = handleClipboardMessage(messageJson)
+        
+        assertTrue("Should handle clipboard-copy message", handledMessage)
+        verify { clipboardHandlerSpy.copyToClipboard("Test copy content") }
+    }
+
+    @Test
+    fun testClipboardCutMessageHandling() = runTest {
+        // Test handling of clipboard-cut messages
+        val cutMessage = JsonObject().apply {
+            addProperty("type", "clipboard-cut")
+            addProperty("text", "Test cut content")
+        }
+        
+        val messageJson = gson.toJson(cutMessage)
+        
+        // Create a spy of WaylandClipboardHandler to verify interaction
+        val clipboardHandlerSpy = spyk<WaylandClipboardHandler>()
+        
+        mockkStatic(WaylandClipboardHandler::class)
+        every { WaylandClipboardHandler() } returns clipboardHandlerSpy
+        every { clipboardHandlerSpy.copyToClipboard(any()) } returns Unit
+        
+        val handledMessage = handleClipboardMessage(messageJson)
+        
+        assertTrue("Should handle clipboard-cut message", handledMessage)
+        verify { clipboardHandlerSpy.copyToClipboard("Test cut content") }
+    }
+
+    @Test
+    fun testNonClipboardMessageHandling() = runTest {
+        // Test that non-clipboard messages are not handled by clipboard logic
+        val regularMessage = JsonObject().apply {
+            addProperty("type", "regular-message")
+            addProperty("data", "Some regular data")
+        }
+        
+        val messageJson = gson.toJson(regularMessage)
+        
+        val handledMessage = handleClipboardMessage(messageJson)
+        
+        assertFalse("Should not handle non-clipboard messages", handledMessage)
+    }
+
+    @Test
+    fun testInvalidJsonMessageHandling() = runTest {
+        // Test handling of invalid JSON messages
+        val invalidJson = "{ invalid json }"
+        
+        val handledMessage = handleClipboardMessage(invalidJson)
+        
+        assertFalse("Should not handle invalid JSON messages", handledMessage)
+    }
+
+    @Test
+    fun testClipboardMessageWithoutText() = runTest {
+        // Test clipboard message without text field
+        val messageWithoutText = JsonObject().apply {
+            addProperty("type", "clipboard-copy")
+            // No text field
+        }
+        
+        val messageJson = gson.toJson(messageWithoutText)
+        
+        val clipboardHandlerSpy = spyk<WaylandClipboardHandler>()
+        mockkStatic(WaylandClipboardHandler::class)
+        every { WaylandClipboardHandler() } returns clipboardHandlerSpy
+        
+        val handledMessage = handleClipboardMessage(messageJson)
+        
+        assertTrue("Should handle clipboard message even without text", handledMessage)
+        // Should not call copyToClipboard when text is null
+        verify(exactly = 0) { clipboardHandlerSpy.copyToClipboard(any()) }
+    }
+
+    @Test
+    fun testClipboardMessageWithEmptyText() = runTest {
+        // Test clipboard message with empty text
+        val messageWithEmptyText = JsonObject().apply {
+            addProperty("type", "clipboard-copy")
+            addProperty("text", "")
+        }
+        
+        val messageJson = gson.toJson(messageWithEmptyText)
+        
+        val clipboardHandlerSpy = spyk<WaylandClipboardHandler>()
+        mockkStatic(WaylandClipboardHandler::class)
+        every { WaylandClipboardHandler() } returns clipboardHandlerSpy
+        every { clipboardHandlerSpy.copyToClipboard(any()) } returns Unit
+        
+        val handledMessage = handleClipboardMessage(messageJson)
+        
+        assertTrue("Should handle clipboard message with empty text", handledMessage)
+        verify { clipboardHandlerSpy.copyToClipboard("") }
+    }
+
+    @Test
+    fun testClipboardHandlerException() = runTest {
+        // Test exception handling in clipboard operations
+        val copyMessage = JsonObject().apply {
+            addProperty("type", "clipboard-copy")
+            addProperty("text", "Test exception handling")
+        }
+        
+        val messageJson = gson.toJson(copyMessage)
+        
+        val clipboardHandlerSpy = spyk<WaylandClipboardHandler>()
+        mockkStatic(WaylandClipboardHandler::class)
+        every { WaylandClipboardHandler() } returns clipboardHandlerSpy
+        every { clipboardHandlerSpy.copyToClipboard(any()) } throws RuntimeException("Clipboard error")
+        
+        // Should not throw exception
+        assertDoesNotThrow("Should handle clipboard exceptions gracefully") {
+            handleClipboardMessage(messageJson)
+        }
+    }
+
+    @Test
+    fun testLargeClipboardContent() = runTest {
+        // Test handling of large clipboard content
+        val largeContent = "x".repeat(10000)
+        val largeMessage = JsonObject().apply {
+            addProperty("type", "clipboard-copy")
+            addProperty("text", largeContent)
+        }
+        
+        val messageJson = gson.toJson(largeMessage)
+        
+        val clipboardHandlerSpy = spyk<WaylandClipboardHandler>()
+        mockkStatic(WaylandClipboardHandler::class)
+        every { WaylandClipboardHandler() } returns clipboardHandlerSpy
+        every { clipboardHandlerSpy.copyToClipboard(any()) } returns Unit
+        
+        val handledMessage = handleClipboardMessage(messageJson)
+        
+        assertTrue("Should handle large clipboard content", handledMessage)
+        verify { clipboardHandlerSpy.copyToClipboard(largeContent) }
+    }
+
+    @Test
+    fun testSpecialCharactersInClipboard() = runTest {
+        // Test handling of special characters in clipboard content
+        val specialContent = "Test with special chars: \n\t\r🚀💻📝\"'\\&<>"
+        val specialMessage = JsonObject().apply {
+            addProperty("type", "clipboard-cut")
+            addProperty("text", specialContent)
+        }
+        
+        val messageJson = gson.toJson(specialMessage)
+        
+        val clipboardHandlerSpy = spyk<WaylandClipboardHandler>()
+        mockkStatic(WaylandClipboardHandler::class)
+        every { WaylandClipboardHandler() } returns clipboardHandlerSpy
+        every { clipboardHandlerSpy.copyToClipboard(any()) } returns Unit
+        
+        val handledMessage = handleClipboardMessage(messageJson)
+        
+        assertTrue("Should handle special characters in clipboard", handledMessage)
+        verify { clipboardHandlerSpy.copyToClipboard(specialContent) }
+    }
+
+    @Test
+    fun testConcurrentClipboardMessages() = runTest {
+        // Test handling of concurrent clipboard messages
+        val messages = (1..5).map { index ->
+            JsonObject().apply {
+                addProperty("type", "clipboard-copy")
+                addProperty("text", "Content $index")
+            }
+        }
+        
+        val clipboardHandlerSpy = spyk<WaylandClipboardHandler>()
+        mockkStatic(WaylandClipboardHandler::class)
+        every { WaylandClipboardHandler() } returns clipboardHandlerSpy
+        every { clipboardHandlerSpy.copyToClipboard(any()) } returns Unit
+        
+        // Process messages concurrently
+        messages.forEach { message ->
+            val messageJson = gson.toJson(message)
+            val handled = handleClipboardMessage(messageJson)
+            assertTrue("Should handle all clipboard messages", handled)
+        }
+        
+        // Verify all messages were processed
+        verify(exactly = 5) { clipboardHandlerSpy.copyToClipboard(any()) }
+    }
+
+    @Test
+    fun testMessageTypeVariations() = runTest {
+        // Test different variations of message types
+        val testCases = listOf(
+            "clipboard-copy" to true,
+            "clipboard-cut" to true,
+            "CLIPBOARD-COPY" to false, // Case sensitive
+            "clipboard_copy" to false, // Different format
+            "clipboardcopy" to false,  // No dash
+            "copy-clipboard" to false, // Wrong order
+            "" to false,               // Empty
+            "other-message" to false   // Different message
+        )
+        
+        val clipboardHandlerSpy = spyk<WaylandClipboardHandler>()
+        mockkStatic(WaylandClipboardHandler::class)
+        every { WaylandClipboardHandler() } returns clipboardHandlerSpy
+        every { clipboardHandlerSpy.copyToClipboard(any()) } returns Unit
+        
+        testCases.forEach { (messageType, shouldHandle) ->
+            val message = JsonObject().apply {
+                addProperty("type", messageType)
+                addProperty("text", "test content")
+            }
+            
+            val messageJson = gson.toJson(message)
+            val handled = handleClipboardMessage(messageJson)
+            
+            assertEquals(
+                "Message type '$messageType' should ${if (shouldHandle) "be" else "not be"} handled",
+                shouldHandle,
+                handled
+            )
+        }
+    }
+
+    /**
+     * Helper method to simulate clipboard message handling logic.
+     * This replicates the logic from WebViewManager.setupJSBridge() for testing.
+     */
+    private fun handleClipboardMessage(message: String): Boolean {
+        return try {
+            val messageObj = gson.fromJson(message, JsonObject::class.java)
+            val messageType = messageObj.get("type")?.asString
+            
+            when (messageType) {
+                "clipboard-copy", "clipboard-cut" -> {
+                    val text = messageObj.get("text")?.asString
+                    if (text != null) {
+                        val clipboardHandler = WaylandClipboardHandler()
+                        clipboardHandler.copyToClipboard(text)
+                    }
+                    true
+                }
+                else -> false
+            }
+        } catch (e: Exception) {
+            false
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR fixes the clipboard paste issue on Linux with Wayland display server, where users cannot paste content from the system clipboard into agent input fields.

## Problem
As reported in [wecode-ai/RunVSAgent#76](https://github.com/wecode-ai/RunVSAgent/issues/76):
- Users can copy and paste text between the system and Android Studio
- Users can copy text from the agent and paste it into other agent input fields
- **However**, users **cannot paste** any content from the system clipboard **into the agent input fields** on Wayland

## Solution
The fix implements a multi-layered approach to handle clipboard operations on both X11 and Wayland:

### 1. Enhanced MainThreadClipboard
- Added IntelliJ's `CopyPasteManager` as the primary clipboard handler for better Wayland compatibility
- Implemented fallback to AWT `Toolkit.getDefaultToolkit().systemClipboard` for X11
- Added environment detection for Wayland display server (`WAYLAND_DISPLAY` and `XDG_SESSION_TYPE`)

### 2. New WaylandClipboardHandler
- Created a dedicated keyboard handler for JCEF WebView
- Intercepts clipboard shortcuts (Ctrl+V, Ctrl+C, Ctrl+X) at the browser level
- Directly injects clipboard content into input fields using JavaScript
- Handles both regular input/textarea elements and contentEditable elements

### 3. WebViewManager Integration
- Integrated the clipboard handler into WebView initialization
- Added message handling for clipboard operations from JavaScript
- Ensures clipboard operations work seamlessly in WebView contexts

## Technical Details
- The solution uses IntelliJ's platform-specific clipboard APIs which have better support for Wayland
- Keyboard events are intercepted at the CEF browser level before they reach the WebView
- JavaScript injection ensures the pasted text properly triggers input events
- The implementation maintains backward compatibility with X11 systems

## Testing
The implementation should be tested on:
- [x] Linux with Wayland (primary target)
- [ ] Linux with X11 (backward compatibility)
- [ ] Other platforms (Windows, macOS) to ensure no regression

## Related Issues
Fixes: https://github.com/wecode-ai/RunVSAgent/issues/76